### PR TITLE
example body to create test-plans throw the /test-plan endpoint 

### DIFF
--- a/5gtango-vnv-examples/planner/test-plans-POST.json
+++ b/5gtango-vnv-examples/planner/test-plans-POST.json
@@ -1,0 +1,326 @@
+{
+  "id": 0,
+  "test_plans": [
+    {
+      "description": "Test Plan Description: Adhoc TD,NSD request for testing at 11:38utc 2019/04/10",
+      "id": 4,
+      "index": 3,
+      "nsd": {
+        "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/service-descriptor/nsd-schema.yml",
+        "vendor": "eu.sonata-nfv",
+        "name": "mediapilot-service",
+        "version": "0.2",
+        "author": "Ignacio Dominguez @: atos",
+        "description": "This NS provides the video streaming service for the immersive media pilot.",
+        "network_functions": [
+          {
+            "vnf_id": "vnf-ma",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-ma",
+            "vnf_version": "0.2"
+          },
+          {
+            "vnf_id": "vnf-mse",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-mse",
+            "vnf_version": "0.2"
+          },
+          {
+            "vnf_id": "vnf-cms",
+            "vnf_vendor": "eu.5gtango",
+            "vnf_name": "vnf-cms",
+            "vnf_version": "0.1"
+          }
+        ],
+        "connection_points": [
+          {
+            "id": "nscpexternal",
+            "interface": "ipv4",
+            "type": "external"
+          }
+        ],
+        "testing_tags": [
+          "packetLossTest"
+        ],
+        "virtual_links": [
+          {
+            "id": "vlexternal",
+            "connectivity_type": "E-LAN",
+            "connection_points_reference": [
+              "vnf-ma:rtmp",
+              "vnf-mse:hls",
+              "vnf-cms:api",
+              "nscpexternal"
+            ]
+          },
+          {
+            "id": "cms-aggregator",
+            "connectivity_type": "E-Line",
+            "connection_points_reference": [
+              "vnf-cms:api",
+              "vnf-ma:api"
+            ]
+          },
+          {
+            "id": "aggregator-mse",
+            "connectivity_type": "E-Line",
+            "connection_points_reference": [
+              "vnf-ma:rtmp",
+              "vnf-mse:rtmp"
+            ]
+          }
+        ]
+      },
+      "status": "string",
+      "testd": {
+        "author": "Ignacio Dominguez, Felipe Vicens (ATOS)",
+        "description": "Performance test for video analysis",
+        "descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/test-descriptor/testdescriptor-schema.yml",
+        "name": "test-immersive-media",
+        "phases": [
+          {
+            "id": "setup",
+            "steps": [
+              {
+                "action": "deploy",
+                "description": "Deploying a NS",
+                "name": "deployment"
+              },
+              {
+                "action": "configure",
+                "description": "Configuration",
+                "name": "configuration",
+                "probes": [
+                  {
+                    "description": "A service initial configuration container",
+                    "id": "initiator",
+                    "image": "ignaciodomin/media-initiator:dev",
+                    "name": "initiator",
+                    "parameters": [
+                      {
+                        "key": "CAMERA",
+                        "value": "test"
+                      },
+                      {
+                        "key": "CMS",
+                        "value": "$(vnf-cms/endpoints/id:floating-ip/address)"
+                      },
+                      {
+                        "key": "MA",
+                        "value": "$(vnf-ma/endpoints/id:floating-ip/address)"
+                      },
+                      {
+                        "key": "MSE",
+                        "value": "$(vnf-mse/endpoints/id:floating-ip/address)"
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Ffprobe",
+                    "id": "ffprobe",
+                    "image": "ignaciodomin/media-ffprobe:dev",
+                    "name": "ffprobe",
+                    "parameters": [
+                      {
+                        "key": "STREAMING_ENGINE",
+                        "value": "$(vnf-mse/endpoints/id:floating-ip/address)"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "plane"
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Parser",
+                    "id": "parser",
+                    "image": "ignaciodomin/media-parser:dev",
+                    "name": "parser",
+                    "parameters": []
+                  },
+                  {
+                    "description": "Content Producer Emulator (CPE) To generate a RTMP flow",
+                    "id": "cpe",
+                    "image": "ignaciodomin/media-cpe:plane",
+                    "name": "cpe",
+                    "parameters": [
+                      {
+                        "key": "AGGREGATOR",
+                        "value": "$(vnf-ma/endpoints/id:floating-ip/address)"
+                      },
+                      {
+                        "key": "APP",
+                        "value": "test"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "test"
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Content Consumer Emulator (CCE) To play HLS flows from Streaming engine",
+                    "id": "cce",
+                    "image": "ignaciodomin/media-cce:dev",
+                    "name": "cce",
+                    "parameters": [
+                      {
+                        "key": "STREAMMING_ENGINE",
+                        "value": "$(vnf-mse/endpoints/id:floating-ip/address)"
+                      },
+                      {
+                        "key": "STREAM",
+                        "value": "test"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "exercise",
+            "steps": [
+              {
+                "command": "/bin/sh",
+                "description": "Starting the CPE that simulates the camera",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 1,
+                "instances": 1,
+                "name": "cpe",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "cpe"
+              },
+              {
+                "description": "Starting the CCE that simulates the consumer",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 2,
+                "instances": 1,
+                "name": "ffprobe",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "ffprobe",
+                "start_delay": 5
+              },
+              {
+                "description": "Starting the CCE that simulates the consumer",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 3,
+                "instances": 1,
+                "name": "cce",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "cce",
+                "start_delay": 20
+              },
+              {
+                "dependencies": [
+                  "cpe",
+                  "ffprobe",
+                  "cce"
+                ],
+                "description": "Starting the CCE that simulates the consumer",
+                "entrypoint": "/app/entrypoint.sh",
+                "index": 4,
+                "instances": 1,
+                "name": "parser",
+                "output": [
+                  {
+                    "results": "logs.txt"
+                  }
+                ],
+                "run": "ffprobe"
+              }
+            ]
+          },
+          {
+            "id": "verification",
+            "steps": [
+              {
+                "conditions": [
+                  {
+                    "condition": "not present",
+                    "file": "status.txt",
+                    "find": "ERROR",
+                    "name": "status",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check cpe",
+                "name": "cpe",
+                "step": "cpe"
+              },
+              {
+                "conditions": [
+                  {
+                    "condition": "not present",
+                    "file": "status.txt",
+                    "find": "ERROR",
+                    "name": "status",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check cce",
+                "name": "cce",
+                "step": "cce"
+              },
+              {
+                "conditions": [
+                  {
+                    "condition": "not present",
+                    "file": "status.txt",
+                    "find": "ERROR",
+                    "name": "status",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check ffprobe",
+                "name": "ffprobe",
+                "step": "ffprobe"
+              },
+              {
+                "conditions": [
+                  {
+                    "condition": "<",
+                    "file": "detail.json",
+                    "find": "error_rate",
+                    "name": "error_rate",
+                    "type": "json",
+                    "value": "0.05",
+                    "verdict": "pass"
+                  }
+                ],
+                "description": "Check obtained results",
+                "name": "parser",
+                "step": "parser"
+              }
+            ]
+          }
+        ],
+        "service_platforms": [
+          "SONATA"
+        ],
+        "test_category": [
+          "benchmarking"
+        ],
+        "test_tags": [
+          "packetLossTest"
+        ],
+        "vendor": "eu.5gtango.atos",
+        "version": "0.1"
+      },
+      "uuid": "17898765456"
+    }
+  ],
+  "uuid": "4256289"
+}


### PR DESCRIPTION
example body to create test-plans throw Planner's /test-plan endpoint 
A howTo simplified example is available to planner swagger in pre-int server:
pre_int_address:6100/tng-vnv-planner/swagger-ui.html#/test-plan-controller/saveUsingPOST